### PR TITLE
:green_heart: Fix runner for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: "Release"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
         uses: actions/checkout@v3


### PR DESCRIPTION
ubuntu 18.04 is no longer available